### PR TITLE
fix(ci): sidebar/ロゴのリンクに base path (/tips) を付与する

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -45,7 +45,7 @@ jobs:
           package-manager: npm@11.9.0
         env:
           # configure-pages が解決した値を astro.config.mjs に渡す
-          BASE_URL: ${{ steps.configure-pages.outputs.origin }}
+          BASE_URL: ${{ steps.configure-pages.outputs.base_url }}
           BASE_PATH: ${{ steps.configure-pages.outputs.base_path }}
 
   deploy:


### PR DESCRIPTION
## 概要

GitHub Pages へのデプロイ後、sidebar やロゴ (site-title) のリンクに base path (`/tips`) が含まれず、リンク先が壊れる問題を修正します。

## 原因

Starlight は sidebar / site-title のリンクを Astro の `site` を基準にした**絶対URL**で生成します。ワークフローでは `site`（= `BASE_URL`）に `configure-pages` の `origin`（`https://ayukiyoshida.github.io`、base path を含まない）を渡していたため、これらの絶対URLから `/tips` が欠落していました。

一方 CSS/アセット等は `base` が効くため正しく、sidebar だけ壊れるという非対称な症状になっていました。

## 修正

`BASE_URL` に `configure-pages` の `origin` ではなく `base_url`（origin + base_path = `https://ayukiyoshida.github.io/tips`）を渡すようにしました。これで `site` に `/tips` が含まれ、sidebar・ロゴの絶対URLにも `/tips` が付きます。

```diff
-          BASE_URL: ${{ steps.configure-pages.outputs.origin }}
+          BASE_URL: ${{ steps.configure-pages.outputs.base_url }}
```

## 検証

ローカルで `astro build` を条件別に実行し、sidebar の href を確認:

| `site` (BASE_URL) | `base` | sidebar の href |
|---|---|---|
| `…github.io` (origin, 修正前) | `/tips` | `…github.io/statistics/outlie/` ❌ `/tips` 欠落 |
| `…github.io/tips` (base_url, 修正後) | `/tips` | `…github.io/tips/statistics/outlie/` ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)